### PR TITLE
[Bugfix:Autograding] Copy only necessary files

### DIFF
--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -22,8 +22,7 @@ mkdir -p "${INSTALLATION_DIR}"
 
 # Copy cloned files to AnalysisToolsTS directory
 if [ $# -eq 0 ]; then
-    rsync -rtz "${REPO_DIR}/src" "${INSTALLATION_DIR}"
-    rsync -rtz "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
+    rsync -rtz "${REPO_DIR}/src" "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
 fi
 
 mkdir -p "${INCLUDE_DIR}"

--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -21,7 +21,10 @@ echo -e "Installing AnalysisToolsTS... "
 mkdir -p "${INSTALLATION_DIR}"
 
 # Copy cloned files to AnalysisToolsTS directory
-rsync -rtz "${REPO_DIR}" "${INSTALLATION_DIR}"
+if [ $# -eq 0 ]; then
+    rsync -rtz "${REPO_DIR}/src" "${INSTALLATION_DIR}"
+    rsync -rtz "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
+fi
 
 mkdir -p "${INCLUDE_DIR}"
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Copies all files in the AnalysisToolsTS repo to the installation directory. This copies CMakeCache files as well which causes failure in installation if there is a local cloned repository

### What is the new behavior?
Copies only the source code and the CMakeLists.txt to installation directory.
### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->