### PR TITLE
[Bugfix:Autograding] Update number of command args

### DIFF
--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -22,8 +22,7 @@ mkdir -p "${INSTALLATION_DIR}"
 
 # Copy cloned files to AnalysisToolsTS directory
 if [ $# -eq 0 ]; then
-    rsync -rtz "${REPO_DIR}/src" "${INSTALLATION_DIR}"
-    rsync -rtz "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
+    rsync -rtz "${REPO_DIR}/src" "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
 fi
 
 mkdir -p "${INCLUDE_DIR}"

--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -21,7 +21,10 @@ echo -e "Installing AnalysisToolsTS... "
 mkdir -p "${INSTALLATION_DIR}"
 
 # Copy cloned files to AnalysisToolsTS directory
-rsync -rtz "${REPO_DIR}" "${INSTALLATION_DIR}"
+if [ $# -eq 0 ]; then
+    rsync -rtz "${REPO_DIR}/src" "${INSTALLATION_DIR}"
+    rsync -rtz "${REPO_DIR}/CMakeLists.txt" "${INSTALLATION_DIR}"
+fi
 
 mkdir -p "${INCLUDE_DIR}"
 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -56,8 +56,7 @@ void diagnose(Parser *parser, const std::vector<std::string> &files) {
       }
     }
   }
-  std::ofstream output_file("out.json");
-  output_file << std::setw(4) << file_nodes_obj << std::endl;
+  std::cout << std::setw(4) << file_nodes_obj << std::endl;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -53,7 +53,7 @@ Countable get_countable(const std::string &arg) {
 
 void parse_args_counter(int argc, char *argv[], Language &lang, Countable &countable, std::string &feature,
                         std::vector<std::string> &files) {
-  std::string usage_format = "Usage: submitty_count_ts -l <language> <countable> <feature> <files>";
+  std::string usage_format = "Usage: submitty_count_ts -l <language> <countable> <feature> <files>...";
   if (argc < 6) {
     std::cerr << "Error: require more arguments" << std::endl;
     std::cerr << usage_format << std::endl;
@@ -82,7 +82,7 @@ void parse_args_counter(int argc, char *argv[], Language &lang, Countable &count
 }
 
 void parse_args_diagnoser(int argc, char *argv[], Language &lang, std::vector<std::string> &files) {
-  std::string usage_format = "Usage: submitty_diagnostics_ts -l <language> <files>";
+  std::string usage_format = "Usage: submitty_diagnostics_ts -l <language> <files>...";
   if (argc < 4) {
     std::cerr << "Error: require more arguments" << std::endl;
     std::cerr << usage_format << std::endl;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -19,7 +19,7 @@ void find_files(const std::string &file_pattern, std::vector<std::string> &files
     exit(EXIT_FAILURE);
     return;
   }
-  files.insert(files.begin(), glob_result.gl_pathv, glob_result.gl_pathv + glob_result.gl_pathc);
+  files.insert(files.end(), glob_result.gl_pathv, glob_result.gl_pathv + glob_result.gl_pathc);
   globfree(&glob_result);
 }
 
@@ -54,7 +54,7 @@ Countable get_countable(const std::string &arg) {
 void parse_args_counter(int argc, char *argv[], Language &lang, Countable &countable, std::string &feature,
                         std::vector<std::string> &files) {
   std::string usage_format = "Usage: submitty_count_ts -l <language> <countable> <feature> <files>";
-  if (argc != 6) {
+  if (argc < 6) {
     std::cerr << "Error: require more arguments" << std::endl;
     std::cerr << usage_format << std::endl;
     exit(EXIT_FAILURE);
@@ -71,7 +71,7 @@ void parse_args_counter(int argc, char *argv[], Language &lang, Countable &count
     } else if (i == 4) {
       feature = argv[i];
       continue;
-    } else if (i == 5) {
+    } else if (i >= 5) {
       find_files(argv[i], files);
       continue;
     }
@@ -83,7 +83,7 @@ void parse_args_counter(int argc, char *argv[], Language &lang, Countable &count
 
 void parse_args_diagnoser(int argc, char *argv[], Language &lang, std::vector<std::string> &files) {
   std::string usage_format = "Usage: submitty_diagnostics_ts -l <language> <files>";
-  if (argc != 4) {
+  if (argc < 4) {
     std::cerr << "Error: require more arguments" << std::endl;
     std::cerr << usage_format << std::endl;
     exit(EXIT_FAILURE);
@@ -94,7 +94,7 @@ void parse_args_diagnoser(int argc, char *argv[], Language &lang, std::vector<st
     } else if (i == 2) {
       lang = get_language(argv[i]);
       continue;
-    } else if (i == 3) {
+    } else if (i >= 3) {
       find_files(argv[i], files);
       continue;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Existing command only supports 6 arguments. When there is multiple files this break.

### What is the new behavior?
Support multiple files in commands. 
### Other information?
<!-- Is this a breaking change? -->
Contains fixes made in the PR #3 as well. 
<!-- How did you test -->