### PR TITLE
[Bugfix:System] Set CMAKE_CXX_STANDARD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Build executable
       run: sudo ./install_analysistoolsts.sh local
     - name: run tests
-      run: python testRunner.py
+      run: python3 testRunner.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,10 @@ on: [push]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Change permission

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
+set (CMAKE_CXX_STANDARD 14)
 
 project(analysis_tools_ts)
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When attempting to build the library on my macOS using clang 13, I get 68 warnings and 20 errors, with this being the bottom most snippet:

```
/Users/mpeveler/code/github/submitty/AnalysisToolsTS/include/json/include/nlohmann/detail/meta/cpp_future.hpp:142:28: warning: alias declarations are a C++11 extension [-Wc++11-extensions]
using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
                           ^
/Users/mpeveler/code/github/submitty/AnalysisToolsTS/include/json/include/nlohmann/detail/meta/cpp_future.hpp:156:33: error: unknown type name 'constexpr'
    static JSON_INLINE_VARIABLE constexpr T value{};
                                ^
/Users/mpeveler/code/github/submitty/AnalysisToolsTS/include/json/include/nlohmann/detail/meta/cpp_future.hpp:156:44: error: expected ';' at end of declaration list
    static JSON_INLINE_VARIABLE constexpr T value{};
                                           ^
                                           ;
/Users/mpeveler/code/github/submitty/AnalysisToolsTS/include/json/include/nlohmann/detail/meta/cpp_future.hpp:161:5: error: unknown type name 'constexpr'
    constexpr T static_const<T>::value;
    ^
/Users/mpeveler/code/github/submitty/AnalysisToolsTS/include/json/include/nlohmann/detail/meta/cpp_future.hpp:161:15: warning: variable templates are a C++14 extension [-Wc++14-extensions]
    constexpr T static_const<T>::value;
```

Each of the warnings / errors have a `-Wc++11-extensions` or `-Wc++14-extensions` mention, and so looking around, it looks like clang requires explicitly setting the version of C++ you want to compile against, defaulting to something older than C++11?

g++ does not have this issue, and compiles just fine out of the box.

### What is the new behavior?

By setting the `CMAKE_CXX_STANDARD` to C++14, both clang and g++ compile fine. I'm not sure if there's any potential downside of including this, other than if new C++ features are included, this line would need to be incremented to that new version. I'm not sure what support for C++17 or C++20 is amongst compilers to know if a newer version should be specified.