### PR TITLE
[Bugfix:System] Bubble errors in install script

### DIFF
--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 ########################################################################################################################
 ########################################################################################################################
 # this script must be run by root or sudo
@@ -41,20 +43,22 @@ do
     if [ -d "${dir}" ]; then
         echo "pulling changes ..."
         # IF THE REPO ALREADY EXISTS...
-        pushd "${dir}" || exit
+        pushd "${dir}"
+
+        CURRENT_BRANCH=$(git branch --show-current)
 
         # PULL CHANGES
         git fetch
         git reset --hard HEAD
-        git merge origin/"$CURRENT_BRANCH"
-        popd || exit
+        git merge origin/"${CURRENT_BRANCH}"
+        popd
 
     else
         # THE REPO DID NOT EXIST
         echo "the repository did not previously exist cloning... "
-        pushd "${INCLUDE_DIR}" || exit
-        git clone --depth 1 "https://github.com/tree-sitter/${repo}" || exit
-        popd || exit
+        pushd "${INCLUDE_DIR}"
+        git clone --depth 1 "https://github.com/tree-sitter/${repo}"
+        popd
 
     fi
 done
@@ -68,11 +72,11 @@ fi
 ########################################################################
 
 # build tree sitter library
-pushd "${INCLUDE_DIR}"/tree-sitter || exit
+pushd "${INCLUDE_DIR}"/tree-sitter
 
 make
 
-popd || exit
+popd
 
 echo "building submitty_count_ts ..."
 
@@ -81,11 +85,11 @@ mkdir -p "${INSTALLATION_DIR}/build"
 
 cmake -S "${INSTALLATION_DIR}" -B "${INSTALLATION_DIR}/build" -DJSONDIR="${NLOHMANN_INCLUDE_DIR}"
 
-pushd "${INSTALLATION_DIR}/build" || exit
+pushd "${INSTALLATION_DIR}/build"
 
 make
 
-popd || exit
+popd
 
 # # change permissions
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

The `install_analysistoolsts.sh` script had a number of lines where if the command failed, then the script would continue running, leading to potentially confusing behavior. This included the lines running `cmake` and `make`.

### What is the new behavior?

We use the [`set -e`](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) builtin to make the script immediately fail if a given command returns a non-zero exit code. This will help make stuff like https://github.com/Submitty/AnalysisToolsTS/runs/7789047623 more clear where it failed on the "run tests" step, but only because the "make" in "Build executable" failed, but since the error wasn't bubbled, "Build executable" was marked as "passing".

As we now fail on any non-zero exit code, we can also remove all of the `|| exit` lines throughout the script as that'll happen implicitly.