### PR TITLE
[Feature:System] Build x86_64 and aarch64 exes on release

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,10 +2,9 @@ name: Build binaries on release
 
 on:
   push:
-    branches:
-      - '*'
     tags:
       - '*'
+
 jobs:
   build:
     name: build

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -2,25 +2,49 @@ name: Build binaries on release
 
 on:
   push:
+    branches:
+      - '*'
     tags:
-      - "*"
+      - '*'
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     defaults:
       run:
         shell: bash
     steps:
     - uses: actions/checkout@v2
-    - name: Change permission
-      run: chmod +x install_analysistoolsts.sh
+    - name: Install dependencies (aarch64)
+      if: matrix.arch == 'aarch64'
+      run: sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+    - name: Set CC / CXX (aarch64)
+      if: matrix.arch == 'aarch64'
+      run: |
+        echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
     - name: Build executable
-      run: sudo ./install_analysistoolsts.sh local
+      run: sudo bash ./install_analysistoolsts.sh local
+    - name: Duplicate executables (x86_64)
+      if: matrix.arch == 'x86_64'
+      run: |
+        cp build/submitty_count_ts build/submitty_count_ts-x86_64
+        cp build/submitty_parse_ts build/submitty_parse_ts-x86_64
+    - name: Move executables (aarch64)
+      if: matrix.arch == 'aarch64'
+      run: |
+        mv build/submitty_count_ts build/submitty_count_ts-aarch64
+        mv build/submitty_parse_ts build/submitty_parse_ts-aarch64
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: executables
+        path: build/submitty_*
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: |
-          build/submitty_count_ts
-          build/submitty_diagnostics_ts
+        files: build/submitty_*

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -31,9 +31,7 @@ jobs:
         echo "CC=${CC}"
         echo "CXX=${CXX}"
     - name: Build executable
-      run: sudo bash ./install_analysistoolsts.sh local
-    - name: Chown executables
-      run: sudo chown -R $USER:$USER build
+      run: bash build.sh
     - name: Duplicate executables (x86_64)
       if: matrix.arch == 'x86_64'
       run: |

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -26,6 +26,10 @@ jobs:
       run: |
         echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
         echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+    - name: Debug output
+      run: |
+        echo "CC=${CC}"
+        echo "CXX=${CXX}"
     - name: Build executable
       run: sudo bash ./install_analysistoolsts.sh local
     - name: Chown executables

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -26,10 +26,6 @@ jobs:
       run: |
         echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
         echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
-    - name: Debug output
-      run: |
-        echo "CC=${CC}"
-        echo "CXX=${CXX}"
     - name: Build executable
       run: bash build.sh
     - name: Duplicate executables (x86_64)

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -34,12 +34,12 @@ jobs:
       if: matrix.arch == 'x86_64'
       run: |
         cp build/submitty_count_ts build/submitty_count_ts-x86_64
-        cp build/submitty_parse_ts build/submitty_parse_ts-x86_64
+        cp build/submitty_diagnostics_ts build/submitty_diagnostics_ts-x86_64
     - name: Move executables (aarch64)
       if: matrix.arch == 'aarch64'
       run: |
         mv build/submitty_count_ts build/submitty_count_ts-aarch64
-        mv build/submitty_parse_ts build/submitty_parse_ts-aarch64
+        mv build/submitty_diagnostics_ts build/submitty_diagnostics_ts-aarch64
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -28,6 +28,8 @@ jobs:
         echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
     - name: Build executable
       run: sudo bash ./install_analysistoolsts.sh local
+    - name: Chown executables
+      run: sudo chown -R $USER:$USER build
     - name: Duplicate executables (x86_64)
       if: matrix.arch == 'x86_64'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
-    - name: Change permission
-      run: chmod +x install_analysistoolsts.sh
     - name: Build executable
-      run: sudo ./install_analysistoolsts.sh local
+      run: bash ./build.sh
     - name: run tests
       run: python3 testRunner.py

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ CUR_DIR=$(dirname "${0}")
 BUILD_DIR=${CUR_DIR}/build
 INCLUDE_DIR=${CUR_DIR}/include
 
-mkdir -p ${BUILD_DIR}
-mkdir -p ${INCLUDE_DIR}
+mkdir -p "${BUILD_DIR}"
+mkdir -p "${INCLUDE_DIR}"
 
 ########################################################################
 
@@ -25,20 +25,20 @@ do
     if [ -d "${dir}" ]; then
         echo "pulling changes ..."
         # IF THE REPO ALREADY EXISTS...
-        pushd ${dir}
+        pushd "${dir}"
 
         CURRENT_BRANCH=$(git branch --show-current)
 
         # PULL CHANGES
         git fetch
         git reset --hard HEAD
-        git merge origin/"${CURRENT_BRANCH}"
+        git merge "origin/${CURRENT_BRANCH}"
 
         popd
     else
         # THE REPO DID NOT EXIST
         echo "the repository did not previously exist cloning... "
-        git clone --depth 1 "https://github.com/tree-sitter/${repo}" ${INCLUDE_DIR}/${repo}
+        git clone --depth 1 "https://github.com/tree-sitter/${repo}" "${INCLUDE_DIR}/${repo}"
     fi
 done
 
@@ -46,31 +46,31 @@ done
 echo "clone or update nlohmann"
 if [ -d "${INCLUDE_DIR}/json" ]; then
   echo "pulling changes ..."
-  pushd ${INCLUDE_DIR}/json
+  pushd "${INCLUDE_DIR}/json"
 
   CURRENT_BRANCH=$(git branch --show-current)
   git fetch
   git reset --hard HEAD
-  git merge origin/${CURRENT_BRANCH}
+  git merge "origin/${CURRENT_BRANCH}"
   popd
 else
-  git clone --depth 1 "https://github.com/nlohmann/json.git" ${INCLUDE_DIR}/json
+  git clone --depth 1 "https://github.com/nlohmann/json.git" "${INCLUDE_DIR}/json"
 fi
 
 
 ########################################################################
 
 # build tree sitter library
-pushd ${INCLUDE_DIR}/tree-sitter
+pushd "${INCLUDE_DIR}/tree-sitter"
 make
 popd
 
 echo "building submitty_count_ts ..."
 
 # Compile the project
-cmake -S ${CUR_DIR} -B ${BUILD_DIR} -DJSONDIR=${INCLUDE_DIR}/json/include
+cmake -S "${CUR_DIR}" -B "${BUILD_DIR}" -DJSONDIR="${INCLUDE_DIR}/json/include"
 
-pushd ${BUILD_DIR}
+pushd "${BUILD_DIR}"
 make
 popd
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Building AnalysisToolsTS... "
+
+CUR_DIR=$(dirname "${0}")
+BUILD_DIR=${CUR_DIR}/build
+INCLUDE_DIR=${CUR_DIR}/include
+
+mkdir -p ${BUILD_DIR}
+mkdir -p ${INCLUDE_DIR}
+
+########################################################################
+
+# Clone the tree-sitter repos
+repos=( tree-sitter tree-sitter-python tree-sitter-c tree-sitter-cpp tree-sitter-java)
+
+for repo in "${repos[@]}"
+do
+    dir="${INCLUDE_DIR}/${repo}"
+
+    echo "clone or update ${repo}... "
+
+    if [ -d "${dir}" ]; then
+        echo "pulling changes ..."
+        # IF THE REPO ALREADY EXISTS...
+        pushd ${dir}
+
+        CURRENT_BRANCH=$(git branch --show-current)
+
+        # PULL CHANGES
+        git fetch
+        git reset --hard HEAD
+        git merge origin/"${CURRENT_BRANCH}"
+
+        popd
+    else
+        # THE REPO DID NOT EXIST
+        echo "the repository did not previously exist cloning... "
+        git clone --depth 1 "https://github.com/tree-sitter/${repo}" ${INCLUDE_DIR}/${repo}
+    fi
+done
+
+# CHECKOUT & INSTALL THE NLOHMANN C++ JSON LIBRARY
+echo "clone or update nlohmann"
+if [ -d "${INCLUDE_DIR}/json" ]; then
+  echo "pulling changes ..."
+  pushd ${INCLUDE_DIR}/json
+
+  CURRENT_BRANCH=$(git branch --show-current)
+  git fetch
+  git reset --hard HEAD
+  git merge origin/${CURRENT_BRANCH}
+  popd
+else
+  git clone --depth 1 "https://github.com/nlohmann/json.git" ${INCLUDE_DIR}/json
+fi
+
+
+########################################################################
+
+# build tree sitter library
+pushd ${INCLUDE_DIR}/tree-sitter
+make
+popd
+
+echo "building submitty_count_ts ..."
+
+# Compile the project
+cmake -S ${CUR_DIR} -B ${BUILD_DIR} -DJSONDIR=${INCLUDE_DIR}/json/include
+
+pushd ${BUILD_DIR}
+make
+popd
+
+echo "Done building AnalysisToolsTS"

--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -71,9 +71,6 @@ fi
 
 ########################################################################
 
-echo "CC=${CC}"
-echo "CXX=${CXX}"
-
 # build tree sitter library
 pushd "${INCLUDE_DIR}"/tree-sitter
 

--- a/install_analysistoolsts.sh
+++ b/install_analysistoolsts.sh
@@ -71,6 +71,9 @@ fi
 
 ########################################################################
 
+echo "CC=${CC}"
+echo "CXX=${CXX}"
+
 # build tree sitter library
 pushd "${INCLUDE_DIR}"/tree-sitter
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

Releases only include binaries for x86_64 linux, and they will not work on aarch64 based machines (like the ones @bmcutler and myself use). As such, the generated containers from https://github.com/Submitty/DockerImages/pull/14 will not work on those machines subsequently. 

### What is the new behavior?

We will now build executables for both x86_64 and aarch64. The release will have the following files:
* submitty_count_ts
* submitty_count_ts-x86_64
* submitty_count_ts-aarch64
* submitty_diagnotics_ts
* submitty_diagnostics_ts-x86-64
* submitty_diagnostics_ts-aarch64

I include the executables without suffix (which are x86_64 based) so as to retain BC with existing systems and that it would be my intention to remove these after a few releases. However, these are small enough that I think it's fine to include them for now.

Additionally, this would also replace what we do in the Submitty repo of cloning this repo and building it with just grabbing executables if we wanted for all targets system archs.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->

The README needs to be updated, but I'll do that after a couple of PRs I've got planned.