### PR TITLE
[Bugfix:Developer] Change scanner.cc to scanner.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(JSONDIR)
 endif()
 
 add_library(tree-sitter-python include/tree-sitter-python/src/parser.c
-                               include/tree-sitter-python/src/scanner.c)
+                               include/tree-sitter-python/src/scanner.cc)
 
 add_library(tree-sitter-cpp include/tree-sitter-cpp/src/parser.c
                             include/tree-sitter-cpp/src/scanner.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ if(JSONDIR)
 endif()
 
 add_library(tree-sitter-python include/tree-sitter-python/src/parser.c
-                               include/tree-sitter-python/src/scanner.cc)
+                               include/tree-sitter-python/src/scanner.c)
 
 add_library(tree-sitter-cpp include/tree-sitter-cpp/src/parser.c
-                            include/tree-sitter-cpp/src/scanner.cc)
+                            include/tree-sitter-cpp/src/scanner.c)
 
 add_library(tree-sitter-c include/tree-sitter-c/src/parser.c)
 


### PR DESCRIPTION
### What is the current behavior?
Submitty CI integration tests fail because tree-sitter package is constantly changing, this time in cpp, the scanner file was refactored to be written in C instead of C++
### What is the new behavior?
This file dependency has been changed to be a .c extension instead of a .cc extension. 
