### PR TITLE
[Bugfix:Developer] Change python scanner.cc to scanner.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(JSONDIR)
 endif()
 
 add_library(tree-sitter-python include/tree-sitter-python/src/parser.c
-                               include/tree-sitter-python/src/scanner.cc)
+                               include/tree-sitter-python/src/scanner.c)
 
 add_library(tree-sitter-cpp include/tree-sitter-cpp/src/parser.c
                             include/tree-sitter-cpp/src/scanner.c)

--- a/versions.sh
+++ b/versions.sh
@@ -9,8 +9,8 @@
 # of locking the version, adjust this to be versions instead of commits
 
 # TREE-SITTER REPOS
-# Python -- Merge pull request #193 from tree-sitter/tausbn/... -- Feb 28, 23
-export tree_sitter_python_hash=62827156d01c74dc1538266344e788da74536b8a
+# Python -- feat: rewrite the scanner in C -- June 23, 23
+export tree_sitter_python_hash=6ecc2b54b39ac390848d81dfcf5ee961f33a2f03
 # Tree-Sitter - Avoid unused value warning from array_pop -- Jun 14, 23
 export tree_sitter_hash=d0029a15273e526925a764033e9b7f18f96a7ce5
 # cpp -- Merge pull request #209 from amaanq/rewrite-it-in-c -- Jun 18, 23


### PR DESCRIPTION
### What is the current behavior?
Tree-sitter compilation fails due to tree-sitter-python having an update where the scanner.cc file was re-written in C as scanner.c

### What is the new behavior?
Scanner.cc has been changed to scanner.c, and the python version updated to match. 