### PR TITLE
[Bugfix:System] add iomanip

### DIFF
--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -6,6 +6,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
+#include <iomanip>
 
 #include "parser.h"
 #include "utils.h"


### PR DESCRIPTION
compilation failed on a system upgrade from Ubuntu 20.04 to Ubuntu 22.04

<img width="1047" alt="Screenshot 2023-08-22 at 9 27 55 PM" src="https://github.com/Submitty/AnalysisToolsTS/assets/5871417/6e3ef8e9-22d8-40a8-bafb-1f78c8d3a665">
